### PR TITLE
Add a LocalCache supporting the W-TinyLFU eviction policy

### DIFF
--- a/prj/coherence-core/src/main/java/com/tangosol/net/cache/FrequencySketch.java
+++ b/prj/coherence-core/src/main/java/com/tangosol/net/cache/FrequencySketch.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * http://oss.oracle.com/licenses/upl.
+ */
+package com.tangosol.net.cache;
+
+/**
+ * A probabilistic multiset for estimating the popularity of an element within a time window. The
+ * maximum frequency of an element is limited to 15 (4-bits) and an aging process periodically
+ * halves the popularity of all elements.
+ *
+ * @author Ben Manes
+ */
+final class FrequencySketch<E> {
+
+  /*
+   * This class maintains a 4-bit CountMinSketch [1] with periodic aging to provide the popularity
+   * history for the TinyLfu admission policy [2]. The time and space efficiency of the sketch
+   * allows it to cheaply estimate the frequency of an entry in a stream of cache access events.
+   *
+   * The counter matrix is represented as a single dimensional array holding 16 counters per slot. A
+   * fixed depth of four balances the accuracy and cost, resulting in a width of four times the
+   * length of the array. To retain an accurate estimation the array's length equals the maximum
+   * number of entries in the cache, increased to the closest power-of-two to exploit more efficient
+   * bit masking. This configuration results in a confidence of 93.75% and error bound of e / width.
+   *
+   * The frequency of all entries is aged periodically using a sampling window based on the maximum
+   * number of entries in the cache. This is referred to as the reset operation by TinyLfu and keeps
+   * the sketch fresh by dividing all counters by two and subtracting based on the number of odd
+   * counters found. The O(n) cost of aging is amortized, ideal for hardware prefetching, and uses
+   * inexpensive bit manipulations per array location.
+   *
+   * [1] An Improved Data Stream Summary: The Count-Min Sketch and its Applications
+   * http://dimacs.rutgers.edu/~graham/pubs/papers/cm-full.pdf
+   * [2] TinyLFU: A Highly Efficient Cache Admission Policy
+   * https://dl.acm.org/citation.cfm?id=3149371
+   */
+
+  static final long[] SEED = { // A mixture of seeds from FNV-1a, CityHash, and Murmur3
+      0xc3a5c85c97cb3127L, 0xb492b66fbe98f273L, 0x9ae16a3b2f90404fL, 0xcbf29ce484222325L};
+  static final long RESET_MASK = 0x7777777777777777L;
+  static final long ONE_MASK = 0x1111111111111111L;
+
+  int sampleSize;
+  int tableMask;
+  long[] table;
+  int size;
+
+  /**
+   * Creates a lazily initialized frequency sketch, requiring {@link #ensureCapacity} be called
+   * when the maximum size of the cache has been determined.
+   */
+  @SuppressWarnings("NullAway.Init")
+  public FrequencySketch() {}
+
+  /**
+   * Initializes and increases the capacity of this <tt>FrequencySketch</tt> instance, if necessary,
+   * to ensure that it can accurately estimate the popularity of elements given the maximum size of
+   * the cache. This operation forgets all previous counts when resizing.
+   *
+   * @param maximumSize the maximum size of the cache
+   */
+  public void ensureCapacity(long maximumSize) {
+    if (maximumSize < 0) {
+      throw new IllegalArgumentException();
+    }
+
+    int maximum = (int) Math.min(maximumSize, Integer.MAX_VALUE >>> 1);
+    if ((table != null) && (table.length >= maximum)) {
+      return;
+    }
+
+    table = new long[(maximum == 0) ? 1 : ceilingPowerOfTwo(maximum)];
+    tableMask = Math.max(0, table.length - 1);
+    sampleSize = (maximumSize == 0) ? 10 : (10 * maximum);
+    if (sampleSize <= 0) {
+      sampleSize = Integer.MAX_VALUE;
+    }
+    size = 0;
+  }
+
+  /**
+   * Returns if the sketch has not yet been initialized, requiring that {@link #ensureCapacity} is
+   * called before it begins to track frequencies.
+   */
+  public boolean isNotInitialized() {
+    return (table == null);
+  }
+
+  /**
+   * Returns the estimated number of occurrences of an element, up to the maximum (15).
+   *
+   * @param e the element to count occurrences of
+   * @return the estimated number of occurrences of the element; possibly zero but never negative
+   */
+  public int frequency(E e) {
+    if (isNotInitialized()) {
+      return 0;
+    }
+
+    int hash = spread(e.hashCode());
+    int start = (hash & 3) << 2;
+    int frequency = Integer.MAX_VALUE;
+    for (int i = 0; i < 4; i++) {
+      int index = indexOf(hash, i);
+      int count = (int) ((table[index] >>> ((start + i) << 2)) & 0xfL);
+      frequency = Math.min(frequency, count);
+    }
+    return frequency;
+  }
+
+  /**
+   * Increments the popularity of the element if it does not exceed the maximum (15). The popularity
+   * of all elements will be periodically down sampled when the observed events exceeds a threshold.
+   * This process provides a frequency aging to allow expired long term entries to fade away.
+   *
+   * @param e the element to add
+   */
+  public void increment(E e) {
+    if (isNotInitialized()) {
+      return;
+    }
+
+    int hash = spread(e.hashCode());
+    int start = (hash & 3) << 2;
+
+    // Loop unrolling improves throughput by 5m ops/s
+    int index0 = indexOf(hash, 0);
+    int index1 = indexOf(hash, 1);
+    int index2 = indexOf(hash, 2);
+    int index3 = indexOf(hash, 3);
+
+    boolean added = incrementAt(index0, start);
+    added |= incrementAt(index1, start + 1);
+    added |= incrementAt(index2, start + 2);
+    added |= incrementAt(index3, start + 3);
+
+    if (added && (++size == sampleSize)) {
+      reset();
+    }
+  }
+
+  /**
+   * Increments the specified counter by 1 if it is not already at the maximum value (15).
+   *
+   * @param i the table index (16 counters)
+   * @param j the counter to increment
+   * @return if incremented
+   */
+  boolean incrementAt(int i, int j) {
+    int offset = j << 2;
+    long mask = (0xfL << offset);
+    if ((table[i] & mask) != mask) {
+      table[i] += (1L << offset);
+      return true;
+    }
+    return false;
+  }
+
+  /** Reduces every counter by half of its original value. */
+  void reset() {
+    int count = 0;
+    for (int i = 0; i < table.length; i++) {
+      count += Long.bitCount(table[i] & ONE_MASK);
+      table[i] = (table[i] >>> 1) & RESET_MASK;
+    }
+    size = (size >>> 1) - (count >>> 2);
+  }
+
+  /**
+   * Returns the table index for the counter at the specified depth.
+   *
+   * @param item the element's hash
+   * @param i the counter depth
+   * @return the table index
+   */
+  int indexOf(int item, int i) {
+    long hash = (item + SEED[i]) * SEED[i];
+    hash += (hash >>> 32);
+    return ((int) hash) & tableMask;
+  }
+
+  /**
+   * Applies a supplemental hash function to a given hashCode, which defends against poor quality
+   * hash functions.
+   */
+  int spread(int x) {
+    x = ((x >>> 16) ^ x) * 0x45d9f3b;
+    x = ((x >>> 16) ^ x) * 0x45d9f3b;
+    return (x >>> 16) ^ x;
+  }
+
+  /** Returns the smallest power of two greater than or equal to {@code x}. */
+  static int ceilingPowerOfTwo(int x) {
+    // From Hacker's Delight, Chapter 3, Harry S. Warren Jr.
+    return 1 << -Integer.numberOfLeadingZeros(x - 1);
+  }
+}

--- a/prj/coherence-core/src/main/java/com/tangosol/net/cache/TinyLfuLocalCache.java
+++ b/prj/coherence-core/src/main/java/com/tangosol/net/cache/TinyLfuLocalCache.java
@@ -1,0 +1,391 @@
+/*
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * http://oss.oracle.com/licenses/upl.
+ */
+package com.tangosol.net.cache;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * A local cache that implementates the Window TinyLFU eviction policy.
+ *
+ * @author Ben Manes
+ */
+@SuppressWarnings({"deprecation", "rawtypes", "unchecked"})
+final class TinyLfuLocalCache extends LocalCache {
+  /*
+   * Maximum size is implemented using the Window TinyLfu policy [1] due to its high hit rate, O(1)
+   * time complexity, and small footprint. A new entry starts in the admission window and remains
+   * there as long as it has high temporal locality (recency). Eventually an entry will slip from
+   * the window into the main space. If the main space is already full, then a historic frequency
+   * filter determines whether to evict the newly admitted entry or the victim entry chosen by the
+   * eviction policy. This process ensures that the entries in the window were very recently used
+   * and entries in the main space are accessed very frequently and are moderately recent. The
+   * windowing allows the policy to have a high hit rate when entries exhibit bursty access pattern
+   * while the filter ensures that popular items are retained. The admission window uses LRU and
+   * the main space uses Segmented LRU.
+   *
+   * The optimal size of the window vs main spaces is workload dependent [2]. A large admission
+   * window is favored by recency-biased workloads while a small one favors frequency-biased
+   * workloads. When the window is too small then recent arrivals are prematurely evicted, but when
+   * too large then they pollute the cache and force the eviction of more popular entries. The
+   * configuration is dynamically determined using hill climbing to walk the hit rate curve. This is
+   * done by sampling the hit rate and adjusting the window size in the direction that is improving
+   * (making positive or negative steps). At each interval the step size is decreased until the
+   * climber converges at the optimal setting. The process is restarted when the hit rate changes
+   * over a threshold, indicating that the workload altered and a new setting may be required.
+   *
+   * The historic usage is retained in a compact popularity sketch, which uses hashing to
+   * probabilistically estimate an item's frequency. This exposes a flaw where an adversary could
+   * use hash flooding [3] to artificially raise the frequency of the main space's victim and cause
+   * all candidates to be rejected. In the worst case, by exploiting hash collisions an attacker
+   * could cause the cache to never hit and hold only worthless items, resulting in a
+   * denial-of-service attack against the underlying resource. This is protected against by
+   * introducing jitter so that candidates which are at least moderately popular have a small,
+   * random chance of being admitted. This causes the victim to be evicted, but in a way that
+   * marginally impacts the hit rate.
+   *
+   * [1] TinyLFU: A Highly Efficient Cache Admission Policy
+   * https://dl.acm.org/citation.cfm?id=3149371
+   * [2] Adaptive Software Cache Management
+   * https://dl.acm.org/citation.cfm?id=3274816
+   * [3] Denial of Service via Algorithmic Complexity Attack
+   * https://www.usenix.org/legacy/events/sec03/tech/full_papers/crosby/crosby.pdf
+   */
+
+  private static final long serialVersionUID = 1L;
+
+  /** The initial percent of the maximum weighted capacity dedicated to the main space. */
+  static final double PERCENT_MAIN = 0.99d;
+  /** The percent of the maximum weighted capacity dedicated to the main's protected space. */
+  static final double PERCENT_MAIN_PROTECTED = 0.80d;
+  /** The difference in hit rates that restarts the climber. */
+  static final double HILL_CLIMBER_RESTART_THRESHOLD = 0.05d;
+  /** The percent of the total size to adapt the window by. */
+  static final double HILL_CLIMBER_STEP_PERCENT = 0.0625d;
+  /** The rate to decrease the step size to adapt by. */
+  static final double HILL_CLIMBER_STEP_DECAY_RATE = 0.98d;
+  /** The maximum number of entries that can be transfered between queues. */
+
+  private final TinyLfuEntry headWindow;
+  private final TinyLfuEntry headProbation;
+  private final TinyLfuEntry headProtected;
+  private final FrequencySketch frequencySketch;
+
+  private int maxWindow;
+  private int maxProtected;
+  private double windowSize;
+  private double protectedSize;
+
+  private int hitsInSample;
+  private int missesInSample;
+  private double previousHitRate;
+
+  private boolean increaseWindow;
+  private double stepSize;
+
+  public TinyLfuLocalCache(int cUnits) {
+    super(cUnits, DEFAULT_EXPIRE);
+    setEvictionPolicy(new TinyLfuPolicy());
+    this.frequencySketch = new FrequencySketch();
+    this.headWindow = new TinyLfuEntry().asSentinel();
+    this.headProbation = new TinyLfuEntry().asSentinel();
+    this.headProtected = new TinyLfuEntry().asSentinel();
+
+    int maxMain = (int) (cUnits * PERCENT_MAIN);
+    this.maxProtected = (int) (maxMain * PERCENT_MAIN_PROTECTED);
+    this.maxWindow = (cUnits - maxMain);
+
+    stepSize = (HILL_CLIMBER_STEP_PERCENT * getHighUnits());
+    frequencySketch.ensureCapacity(m_cMaxUnits);
+  }
+
+  @Override
+  public synchronized void setHighUnits(int cMax) {
+    super.setHighUnits(cMax);
+    if (frequencySketch != null) {
+      frequencySketch.ensureCapacity(m_cMaxUnits);
+    }
+  }
+
+  @Override
+  public Object put(Object key, Object value, long millis) {
+    synchronized (this) {
+      frequencySketch.increment(key);
+    }
+    Object prior = super.put(key, value, millis);
+    if (prior == null) {
+      synchronized (this) {
+        missesInSample++;
+      }
+    }
+    return prior;
+  }
+
+  @Override
+  protected Entry instantiateEntry() {
+    return new TinyLfuEntry();
+  }
+
+  private void onHit(TinyLfuEntry entry) {
+    //frequencySketch.increment(entry.getKey());
+    if (entry.queue == QueueType.WINDOW) {
+      onWindowHit(entry);
+    } else if (entry.queue == QueueType.PROBATION) {
+      onProbationHit(entry);
+    } else if (entry.queue == QueueType.PROTECTED) {
+      onProtectedHit(entry);
+    } else {
+      throw new IllegalStateException();
+    }
+    hitsInSample++;
+    climb(entry);
+  }
+
+  /** Moves the entry to the MRU position in the admission window. */
+  private void onWindowHit(TinyLfuEntry node) {
+    node.moveToTail(headWindow);
+  }
+
+  /** Promotes the entry to the protected region's MRU position, demoting an entry if necessary. */
+  private void onProbationHit(TinyLfuEntry node) {
+    node.remove();
+    node.queue = QueueType.PROTECTED;
+    node.appendToTail(headProtected);
+
+    protectedSize++;
+    demoteProtected();
+  }
+
+  private void demoteProtected() {
+    if (protectedSize > maxProtected) {
+      TinyLfuEntry demote = headProtected.next;
+      demote.remove();
+      demote.queue = QueueType.PROBATION;
+      demote.appendToTail(headProbation);
+      protectedSize--;
+    }
+  }
+
+  /** Moves the entry to the MRU position, if it falls outside of the fast-path threshold. */
+  private void onProtectedHit(TinyLfuEntry node) {
+    node.moveToTail(headProtected);
+  }
+
+  /**
+   * Evicts from the admission window into the probation space. If the size exceeds the maximum,
+   * then the admission candidate and probation's victim are evaluated and one is evicted.
+   */
+  @Override
+  public synchronized void evict() {
+    if (windowSize <= maxWindow) {
+      return;
+    }
+
+    TinyLfuEntry candidate = headWindow.next;
+    windowSize -= candidate.getUnits();
+
+    candidate.remove();
+    candidate.queue = QueueType.PROBATION;
+    candidate.appendToTail(headProbation);
+
+    if (getUnits() > getHighUnits()) {
+      TinyLfuEntry victim = headProbation.next;
+      TinyLfuEntry evict = admit(candidate, victim) ? victim : candidate;
+      removeEvicted(evict);
+    }
+  }
+
+  /**
+   * Determines if the candidate should be accepted into the main space, as determined by its
+   * frequency relative to the victim. A small amount of randomness is used to protect against hash
+   * collision attacks, where the victim's frequency is artificially raised so that no new entries
+   * are admitted.
+   *
+   * @param candidateKey the key for the entry being proposed for long term retention
+   * @param victimKey the key for the entry chosen by the eviction policy for replacement
+   * @return if the candidate should be admitted and the victim ejected
+   */
+  private boolean admit(TinyLfuEntry candidate, TinyLfuEntry victim) {
+    int victimFreq = frequencySketch.frequency(victim.getKey());
+    int candidateFreq = frequencySketch.frequency(candidate.getKey());
+    if (candidateFreq > victimFreq) {
+      return true;
+    } else if (candidateFreq <= 5) {
+      // The maximum frequency is 15 and halved to 7 after a reset to age the history. An attack
+      // exploits that a hot candidate is rejected in favor of a hot victim. The threshold of a warm
+      // candidate reduces the number of random acceptances to minimize the impact on the hit rate.
+      return false;
+    }
+    int random = ThreadLocalRandom.current().nextInt();
+    return ((random & 127) == 0);
+  }
+
+  /** Performs the hill climbing process. */
+  private void climb(TinyLfuEntry entry) {
+    boolean isFull = getUnits() >= getHighUnits();
+    if (!isFull) {
+      return;
+    }
+
+    int sampleCount = (hitsInSample + missesInSample);
+    if (sampleCount < frequencySketch.sampleSize) {
+      return;
+    }
+
+    double hitRate = (double) hitsInSample / sampleCount;
+    double amount = adjust(hitRate);
+    if (amount > 0) {
+      increaseWindow(amount);
+    } else if (amount < 0) {
+      decreaseWindow(-amount);
+    }
+    resetSample(hitRate);
+  }
+
+  private double adjust(double hitRate) {
+    if (hitRate < previousHitRate) {
+      increaseWindow = !increaseWindow;
+    }
+    if (Math.abs(hitRate - previousHitRate) >= HILL_CLIMBER_RESTART_THRESHOLD) {
+      stepSize = (HILL_CLIMBER_STEP_PERCENT * getHighUnits());
+    }
+    return increaseWindow ? stepSize : -stepSize;
+  }
+
+  /** Starts the next sample period. */
+  protected void resetSample(double hitRate) {
+    hitsInSample = 0;
+    missesInSample = 0;
+    previousHitRate = hitRate;
+    stepSize *= HILL_CLIMBER_STEP_DECAY_RATE;
+  }
+
+  private void increaseWindow(double amount) {
+    if (maxProtected == 0) {
+      return;
+    }
+
+    double quota = Math.min(amount, maxProtected);
+    int steps = (int) (windowSize + quota) - (int) windowSize;
+    windowSize += quota;
+
+    for (int i = 0; i < steps; i++) {
+      maxWindow++;
+      maxProtected--;
+
+      demoteProtected();
+      TinyLfuEntry candidate = headProbation.next;
+      candidate.remove();
+      candidate.queue = QueueType.WINDOW;
+      candidate.appendToTail(headWindow);
+    }
+  }
+
+  private void decreaseWindow(double amount) {
+    if (maxWindow == 0) {
+      return;
+    }
+
+    double quota = Math.min(amount, maxWindow);
+    int steps = (int) windowSize - (int) (windowSize - quota);
+    windowSize -= quota;
+
+    for (int i = 0; i < steps; i++) {
+      maxWindow--;
+      maxProtected++;
+
+      TinyLfuEntry candidate = headWindow.next;
+      candidate.remove();
+      candidate.queue = QueueType.PROBATION;
+      candidate.appendToHead(headProbation);
+    }
+  }
+
+  private enum QueueType {
+    WINDOW, PROBATION, PROTECTED
+  }
+
+  public final class TinyLfuEntry extends LocalCache.Entry {
+    private static final long serialVersionUID = 1L;
+
+    private TinyLfuEntry prev;
+    private TinyLfuEntry next;
+    private QueueType queue;
+
+    TinyLfuEntry asSentinel() {
+      prev = this;
+      next = this;
+      return this;
+    }
+
+    @Override
+    public void onAdd() {
+      super.onAdd();
+
+      synchronized (TinyLfuLocalCache.this) {
+        if (getUnits() != -1) {
+          appendToTail(headWindow);
+          windowSize += getUnits();
+          queue = QueueType.WINDOW;
+        }
+      }
+    }
+
+    @Override
+    protected void discard() {
+      if (!isDiscarded()) {
+        remove();
+      }
+      super.discard();
+    }
+
+    public void moveToTail(TinyLfuEntry head) {
+      remove();
+      appendToTail(head);
+    }
+
+    /** Appends the entry to the tail of the list. */
+    public void appendToHead(TinyLfuEntry head) {
+      TinyLfuEntry first = head.next;
+      head.next = this;
+      first.prev = this;
+      prev = head;
+      next = first;
+    }
+
+    /** Appends the entry to the tail of the list. */
+    public void appendToTail(TinyLfuEntry head) {
+      TinyLfuEntry tail = head.prev;
+      head.prev = this;
+      tail.next = this;
+      next = head;
+      prev = tail;
+    }
+
+    /** Removes the entry from the list. */
+    public void remove() {
+      prev.next = next;
+      next.prev = prev;
+      next = prev = null;
+    }
+  }
+
+  private final class TinyLfuPolicy implements ConfigurableCacheMap.EvictionPolicy {
+
+    @Override
+    public String getName() {
+      return "TinyLfu";
+    }
+
+    @Override
+    public void entryTouched(ConfigurableCacheMap.Entry entry) {
+      onHit((TinyLfuEntry) entry);
+    }
+
+    @Override
+    public void requestEviction(int cMaximum) {
+      evict();
+    }
+  }
+}


### PR DESCRIPTION
Window TinyLFU (W-TinyLFU) is a modern eviction policy that
outperforms the currently implemented algorithms: LRU, LFU,
and Hybrid (default).

W-TinyLFU utilizes a popularity sketch, CountMin, to compactly
estimate the frequency over a time period. This sketch is used
as a frequency filter by comparing the entry being added to the
cache to eviction policy's victim. If the victim is more popular
then the candidate is discarded, which avoids polluting the cache
with "one-hit wonders". The sketch is aged by halving all of its
counters periodically. Because it only needs to detect heavy
hitters, a matrix of 4-bit counters is used.

In recency-biased workloads, aggressively filtering by the
frequency can reduce the hit rate. Therefore the cache is split
into two LRUs, one before and one after the filter, and uses
TinyLFU to conditionally promote. Thus the admission window's
viction and the main space's compete. Since the main region is
frequency-biased, it uses SLRU to choose a better victim.

The optimal relative size of these two regions is workload
dependent. It is configured dynamically by using hill climbing.
The hit rate is sampled and the admission window's size is
increased or decreased depending on whether the last guess was
beneficial. Eventually the climber oscillates around the best
configuration, so the step size decays gradually to allow for
convergence. An adaption will restart if the hit rate change
dramatically, indicating new different workload.

The hit rate across a variety of workloads shows a significant
improvement.
 - glimpse: An analytical loop
 - multi3: four concurrent workloads
 - corda: blockchain mining
 - loop/corda/loop: chaining of mru/lru/mru traces
 - oltp: from a CODASYL database
 - ds1: from a SQL database
 - s3: from a web search engine

| Trace | Cache Size | W-TinyLFU | Hybrid | Lru | Optimal |
|---|---|---|---|---|---|
| glimpse | 512 | **32.65%** | 2.64% | 0.98% | 35.13% |
| multi3 | 512 | **44.16%** | 31.41% | 32.78% | 49.10% |
| corda | 512 | 32.29% | 12.14% | **33.33%** | 33.33% |
| loop/corda/loop | 512 | **36.44%** | 14.95% | 21.65% | 39.38% |
| oltp | 1024 | **40.21%** | 15.39% | 33.22% | 53.86% |
| ds1 | 4M | **44.76%** | 36.95% | 20.24% | 48.09% |
| s3 | 400K | **42.52%** | 31.32% | 12.04% | 59.96% |

---

This PR is ports the algorithms into Coherence. If proved desirable, it
would be ideal for a core member to pick up the changes and adapt it to
better fit the code base. For example style, tests, API, etc.