### PR TITLE
Updated BDB version to one available in maven central

### DIFF
--- a/prj/pom.xml
+++ b/prj/pom.xml
@@ -793,7 +793,7 @@
     <annotation-api.version>1.3.5</annotation-api.version>
     <asciidoctor.diagram.version>2.0.2</asciidoctor.diagram.version>
     <asm.version>8.0.1</asm.version>
-    <bdb.version>6.2.31</bdb.version>
+    <bdb.version>18.3.12</bdb.version>
     <bnd.version>4.3.0</bnd.version>
     <cdi-api.version>2.0.2</cdi-api.version>
     <codemodel.version>2.6</codemodel.version>


### PR DESCRIPTION
BDB version referenced in the poms is not available in maven central so build fails. 

Signed-off-by: smillidge <steve.millidge@payara.fish>