### PR TITLE
Upgrade Log4J 2.16.0 to 2.17.0

### DIFF
--- a/prj/test/distribution/jcache-compliance/pom.xml
+++ b/prj/test/distribution/jcache-compliance/pom.xml
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
-      <version>1.2.16</version>
+      <version>1.2.17</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Motivation:

Log4J upgrade to address a security risk CVE-2021-45105

Modifications:

Upgrade from 2.16.0 to 2.17.0

Result:

Using a safer Log4J version