### PR TITLE
Fix unit factor usage in Caffeine cache

### DIFF
--- a/prj/coherence-dependencies/pom.xml
+++ b/prj/coherence-dependencies/pom.xml
@@ -156,7 +156,7 @@
     <asm.version>9.3</asm.version>
     <bdb.version>6.2.31</bdb.version>
     <bnd.version>5.2.0</bnd.version>
-    <caffeine.version>3.1.0</caffeine.version>
+    <caffeine.version>3.1.1</caffeine.version>
     <codemodel.version>2.6</codemodel.version>
     <com.oracle.ipc.version>12.1.4-150528</com.oracle.ipc.version>
     <!-- NOTE: this version should ideally be in sync' with that used by Helidon microprofile -->

--- a/prj/test/unit/coherence-core-tests/src/test/java/com/oracle/coherence/caffeine/CaffeineCacheTest.java
+++ b/prj/test/unit/coherence-core-tests/src/test/java/com/oracle/coherence/caffeine/CaffeineCacheTest.java
@@ -76,7 +76,7 @@ public final class CaffeineCacheTest
 
     @ParameterizedTest
     @MethodSource("caches")
-    public void weight(ConfigurableCacheMap cache)
+    public void smallUnits(ConfigurableCacheMap cache)
         {
         cache.setUnitCalculator(new FixedCalculator(10));
         cache.setHighUnits(100);
@@ -88,6 +88,27 @@ public final class CaffeineCacheTest
         cache.setUnitCalculator(new FixedCalculator(20));
         assertThat(cache.getCacheEntry(1).getUnits(), is(20));
         assertThat(cache.getUnits(), is(10));
+        }
+
+    @ParameterizedTest
+    @MethodSource("caches")
+    public void largeUnits(ConfigurableCacheMap cache)
+        {
+        int cSize = 4;
+        int nUnitFactor = 8;
+        int cMaximum = Integer.MAX_VALUE;
+
+        cache.setHighUnits(cMaximum);
+        cache.setUnitFactor(nUnitFactor);
+        cache.setUnitCalculator(new FixedCalculator(cMaximum));
+        for (int i = 0; i < cSize; i++)
+            {
+            cache.put(i, i);
+            assertThat(cache.getCacheEntry(i).getUnits(), is(cMaximum));
+            }
+
+        int cExpectedUnits = (int) ((((long) cSize * cMaximum) + nUnitFactor - 1) / nUnitFactor);
+        assertThat(cache.getUnits(), is(cExpectedUnits));
         }
 
     @ParameterizedTest


### PR DESCRIPTION
Fix the calculation based on what @aseovic explained to me over slack. I had mistakenly thought this was to change the base unit of the entry's weight, e.g. from bytes to kilobytes, so that larger values could be stored. Instead it is to allow the total capacity to be reported as an `int` instead of a `long`, since that fix would be a breaking API change.

A minor cleanup was to allocate a `CacheEvent` instance only if it the cache will actually fire the event. Since `MapListenerSupport#fireEvent` is a synchronous call even if no listeners are registered (see `collectListeners`), the unsynchronized `isEmpty()` method is called as a guard. It's probably better to prefer avoiding the allocation over the convenience method as not much of a difference in readability.