### PR TITLE
remove SecurityManager references

### DIFF
--- a/prj/coherence-core-21/src/main/java/com/tangosol/internal/util/VirtualThreads.java
+++ b/prj/coherence-core-21/src/main/java/com/tangosol/internal/util/VirtualThreads.java
@@ -65,7 +65,7 @@ public class VirtualThreads
         //              caller context; virtual threads have no permissions
         //              when executing code that performs a privileged
         //              action.
-        return System.getSecurityManager() == null;
+        return true;
         }
 
     /**

--- a/prj/coherence-core-components/src/main/java/com/tangosol/coherence/component/net/Cluster.java
+++ b/prj/coherence-core-components/src/main/java/com/tangosol/coherence/component/net/Cluster.java
@@ -620,20 +620,6 @@ public class Cluster
             (List) config.getServiceFilterMap().get(sServiceType));
         }
     
-    /**
-     * Security check.
-     */
-    protected void checkShutdownPermission()
-        {
-        // import com.tangosol.net.security.LocalPermission;
-        
-        SecurityManager security = System.getSecurityManager();
-        if (security != null)
-            {
-            security.checkPermission(
-                new LocalPermission("Cluster.shutdown"));
-            }
-        }
     
     // From interface: com.tangosol.net.Cluster
     /**
@@ -3357,7 +3343,6 @@ public class Cluster
             case STATE_RUNNING:
                 try
                     {
-                    checkShutdownPermission();
         
                     // shutdown services in reverse order (i.e. shut down system services last)
                     setState(STATE_LEAVING);
@@ -3567,7 +3552,6 @@ public class Cluster
         
         if (getState() != STATE_EXITED)
             {
-            checkShutdownPermission();
         
             setState(STATE_STOPPING);
             try

--- a/prj/coherence-core-components/src/main/java/com/tangosol/coherence/component/net/management/Gateway.java
+++ b/prj/coherence-core-components/src/main/java/com/tangosol/coherence/component/net/management/Gateway.java
@@ -813,13 +813,7 @@ public class Gateway
     public Object execute(com.tangosol.util.function.Remote.Function function)
         {
         // import com.tangosol.util.Base;
-        
-        SecurityManager security = System.getSecurityManager();
-        if (security != null)
-            {
-            security.checkPermission(EXECUTE_PERMISSION);
-            }
-        
+               
         return executeInternal(function, /*continuation*/ null);
         }
     

--- a/prj/coherence-core-components/src/main/java/com/tangosol/coherence/component/util/BackingMapManagerContext.java
+++ b/prj/coherence-core-components/src/main/java/com/tangosol/coherence/component/util/BackingMapManagerContext.java
@@ -361,16 +361,7 @@ public abstract class BackingMapManagerContext
     * The ClassLoader associated with this context.
      */
     public void setClassLoader(ClassLoader loader)
-        {
-        // import com.tangosol.net.security.LocalPermission;
-        
-        SecurityManager security = System.getSecurityManager();
-        if (security != null)
-            {
-            security.checkPermission(
-                new LocalPermission("BackingMapManagerContext.setClassLoader"));
-            }
-        
+        {      
         __m_ClassLoader = (loader);
         }
     

--- a/prj/coherence-core-components/src/main/java/com/tangosol/coherence/component/util/SafeCluster.java
+++ b/prj/coherence-core-components/src/main/java/com/tangosol/coherence/component/util/SafeCluster.java
@@ -381,18 +381,7 @@ public class SafeCluster
         return ((com.tangosol.net.Cluster) getRunningCluster()).unregisterResource(sName);
         }
     //-- com.tangosol.net.Cluster integration
-    
-    private void checkInternalAccess()
-        {
-        // import com.tangosol.net.security.LocalPermission;
         
-        SecurityManager security = System.getSecurityManager();
-        if (security != null)
-            {
-            security.checkPermission(LocalPermission.INTERNAL_SERVICE);
-            }
-        }
-    
     protected void cleanup()
         {
         setInternalCluster(null);
@@ -588,9 +577,7 @@ public class SafeCluster
         // import Component.Net.Cluster;
         // import Component.Net.Management.Gateway;
         // import com.tangosol.net.management.Registry;
-        
-        checkInternalAccess();
-        
+                
         Cluster cluster = getInternalCluster();
         if (cluster == null || !cluster.isRunning())
             {
@@ -722,9 +709,7 @@ public class SafeCluster
         action.setServiceName(sName);
         action.setServiceType(sType);
         
-        return (Service) (System.getSecurityManager() == null
-                 ? action.run()
-                 : AccessController.doPrivileged(new DoAsAction(action)));
+        return (Service)  action.run();
         }
     
     // From interface: com.oracle.coherence.common.base.Lockable
@@ -755,7 +740,6 @@ public class SafeCluster
      */
     public com.tangosol.coherence.component.net.Cluster getCluster()
         {
-        checkInternalAccess();
         
         return getInternalCluster();
         }
@@ -955,15 +939,8 @@ public class SafeCluster
         {
         // import Component.Net.Cluster;
         // import com.tangosol.net.security.DoAsAction;
-        // import java.security.AccessController;
         
-        if (System.getSecurityManager() == null)
-            {
             return ensureRunningCluster();
-            }
-        
-        return (Cluster) AccessController.doPrivileged(
-            new DoAsAction(getEnsureClusterAction()));
         }
     
     // Accessor for the property "ScopedServiceStore"

--- a/prj/coherence-core-components/src/main/java/com/tangosol/coherence/component/util/SafeNamedCache.java
+++ b/prj/coherence-core-components/src/main/java/com/tangosol/coherence/component/util/SafeNamedCache.java
@@ -749,18 +749,7 @@ public class SafeNamedCache
         
         return MapListener.ASYNCHRONOUS | MapListener.VERSION_AWARE;
         }
-    
-    private void checkInternalAccess()
-        {
-        // import com.tangosol.net.security.LocalPermission;
         
-        SecurityManager security = System.getSecurityManager();
-        if (security != null)
-            {
-            security.checkPermission(LocalPermission.INTERNAL_SERVICE);
-            }
-        }
-    
     // From interface: com.tangosol.net.NamedCache
     public void destroy()
         {
@@ -848,7 +837,6 @@ public class SafeNamedCache
         {
         // import com.tangosol.net.NamedCache;
         
-        checkInternalAccess();
         
         NamedCache  cache       = getInternalNamedCache();
         SafeService serviceSafe = getSafeCacheService();
@@ -1030,8 +1018,7 @@ public class SafeNamedCache
      */
     public com.tangosol.net.NamedCache getNamedCache()
         {
-        checkInternalAccess();
-        
+    	
         return getInternalNamedCache();
         }
     
@@ -1162,15 +1149,8 @@ public class SafeNamedCache
         {
         // import com.tangosol.net.NamedCache;
         // import com.tangosol.net.security.DoAsAction;
-        // import java.security.AccessController;
         
-        if (System.getSecurityManager() == null)
-            {
             return ensureRunningNamedCache();
-            }
-        
-        return (NamedCache) AccessController.doPrivileged(
-            new DoAsAction(getEnsureCacheAction()));
         }
     
     // Accessor for the property "SafeAsyncNamedCache"

--- a/prj/coherence-core-components/src/main/java/com/tangosol/coherence/component/util/SafeNamedTopic.java
+++ b/prj/coherence-core-components/src/main/java/com/tangosol/coherence/component/util/SafeNamedTopic.java
@@ -276,16 +276,6 @@ public class SafeNamedTopic
         }
     //-- com.tangosol.net.topic.NamedTopic integration
     
-    private void checkInternalAccess()
-        {
-        // import com.tangosol.net.security.LocalPermission;
-        
-        SecurityManager security = System.getSecurityManager();
-        if (security != null)
-            {
-            security.checkPermission(LocalPermission.INTERNAL_SERVICE);
-            }
-        }
     
     // From interface: com.tangosol.net.topic.NamedTopic
     public com.tangosol.net.topic.Publisher createPublisher(com.tangosol.net.topic.Publisher.Option[] options)
@@ -422,9 +412,7 @@ public class SafeNamedTopic
     public com.tangosol.net.topic.NamedTopic ensureRunningNamedTopic()
         {
         // import com.tangosol.net.topic.NamedTopic;
-        
-        checkInternalAccess();
-        
+                
         NamedTopic  topic       = getInternalNamedTopic();
         SafeService serviceSafe = getSafeTopicService();
         
@@ -542,8 +530,7 @@ public class SafeNamedTopic
      */
     public com.tangosol.net.topic.NamedTopic getNamedTopic()
         {
-        checkInternalAccess();
-        
+    	
         return getInternalNamedTopic();
         }
     
@@ -574,15 +561,8 @@ public class SafeNamedTopic
         {
         // import com.tangosol.net.topic.NamedTopic;
         // import com.tangosol.net.security.DoAsAction;
-        // import java.security.AccessController;
         
-        if (System.getSecurityManager() == null)
-            {
             return ensureRunningNamedTopic();
-            }
-        
-        return (NamedTopic) AccessController.doPrivileged(
-            new DoAsAction(getEnsureTopicAction()));
         }
     
     // Accessor for the property "SafeTopicService"

--- a/prj/coherence-core-components/src/main/java/com/tangosol/coherence/component/util/SafeService.java
+++ b/prj/coherence-core-components/src/main/java/com/tangosol/coherence/component/util/SafeService.java
@@ -471,18 +471,7 @@ public class SafeService
                 }     
             }
         }
-    
-    private void checkInternalAccess()
-        {
-        // import com.tangosol.net.security.LocalPermission;
         
-        SecurityManager security = System.getSecurityManager();
-        if (security != null)
-            {
-            security.checkPermission(LocalPermission.INTERNAL_SERVICE);
-            }
-        }
-    
     protected void cleanup()
         {
         // import com.tangosol.util.SimpleResourceRegistry;
@@ -579,9 +568,7 @@ public class SafeService
         // import com.tangosol.net.InvocationService;
         // import com.tangosol.net.ProxyService;
         // import com.tangosol.net.Service;
-        
-        checkInternalAccess();
-        
+                
         Service service = getInternalService();
         if (service == null || !service.isRunning())
             {
@@ -763,15 +750,7 @@ public class SafeService
         {
         // import com.tangosol.net.Service;
         // import com.tangosol.net.security.DoAsAction;
-        // import java.security.AccessController;
-        
-        if (System.getSecurityManager() == null)
-            {
             return ensureRunningService();
-            }
-        
-        return (Service) AccessController.doPrivileged(
-            new DoAsAction(getEnsureServiceAction()));
         }
     
     // Accessor for the property "SafeCluster"
@@ -804,8 +783,7 @@ public class SafeService
      */
     public com.tangosol.net.Service getService()
         {
-        checkInternalAccess();
-        
+    	
         return getInternalService();
         }
     
@@ -1151,14 +1129,7 @@ public class SafeService
         {
         // import com.tangosol.net.security.LocalPermission;
         // import com.tangosol.net.Service;
-        
-        SecurityManager security = System.getSecurityManager();
-        if (security != null && loader != null)
-            {
-            security.checkPermission(
-                new LocalPermission("BackingMapManagerContext.setClassLoader"));
-            }
-        
+                
         __m_ContextClassLoader = (loader);
         
         Service service = getInternalService();

--- a/prj/coherence-core-components/src/main/java/com/tangosol/coherence/component/util/ShutdownHook.java
+++ b/prj/coherence-core-components/src/main/java/com/tangosol/coherence/component/util/ShutdownHook.java
@@ -183,17 +183,7 @@ public abstract class ShutdownHook
     public void unregister()
         {
         // import com.tangosol.net.security.DoAsAction;
-        // import java.security.AccessController;
-        
-        if (System.getSecurityManager() == null)
-            {
             unregisterInternal();
-            }
-        else
-            {
-            AccessController.doPrivileged(
-                new DoAsAction((ShutdownHook.UnregisterAction) _newChild("UnregisterAction")));
-            }
         }
     
     /**

--- a/prj/coherence-core-components/src/main/java/com/tangosol/coherence/component/util/daemon/queueProcessor/service/Grid.java
+++ b/prj/coherence-core-components/src/main/java/com/tangosol/coherence/component/util/daemon/queueProcessor/service/Grid.java
@@ -770,20 +770,6 @@ public abstract class Grid
         return cTimeoutMillis;
         }
     
-    /**
-     * Security check.
-     */
-    protected void checkShutdownPermission()
-        {
-        // import com.tangosol.net.security.LocalPermission;
-        
-        SecurityManager security = System.getSecurityManager();
-        if (security != null)
-            {
-            security.checkPermission(
-                new LocalPermission("Cluster.shutdown"));
-            }
-        }
     
     // Declared at the super level
     /**
@@ -4955,7 +4941,6 @@ public abstract class Grid
             {
             if (getServiceState() < SERVICE_STOPPING)
                 {
-                checkShutdownPermission();
         
                 // send the request to shut down
                 send(instantiateMessage("NotifyShutdown"));
@@ -5019,9 +5004,7 @@ public abstract class Grid
     public void stop()
         {
         // import com.tangosol.internal.util.NullMessagePublisher;
-        
-        checkShutdownPermission();
-        
+                
         setMessagePublisher(NullMessagePublisher.INSTANCE); // prevent further external communication
         
         super.stop();

--- a/prj/coherence-core-components/src/main/java/com/tangosol/coherence/component/util/daemon/queueProcessor/service/grid/partitionedService/PartitionedCache.java
+++ b/prj/coherence-core-components/src/main/java/com/tangosol/coherence/component/util/daemon/queueProcessor/service/grid/partitionedService/PartitionedCache.java
@@ -24136,9 +24136,7 @@ public class PartitionedCache
                 Storage storage   = getStorage();
                 Map      mapStatus = (Map) ctx.getStorageStatusMap().get(storage);
                 
-                Map mapResource = System.getSecurityManager() == null
-                        ? storage.getBackingMapInternal()
-                        : (Map) AccessController.doPrivileged(new DoAsAction(storage.getBackingMapAction()));
+                Map mapResource = storage.getBackingMapInternal();
                 
                 Storage.EntryStatus status = mapStatus == null ? null : (Storage.EntryStatus) mapStatus.get((Binary) oKey);
                 

--- a/prj/coherence-core-components/src/main/java/com/tangosol/coherence/component/util/daemon/queueProcessor/service/grid/partitionedService/partitionedCache/Storage.java
+++ b/prj/coherence-core-components/src/main/java/com/tangosol/coherence/component/util/daemon/queueProcessor/service/grid/partitionedService/partitionedCache/Storage.java
@@ -3390,13 +3390,6 @@ public class Storage
      */
     public com.tangosol.util.ObservableMap getBackingMap()
         {
-        // import com.tangosol.net.security.LocalPermission;
-
-        SecurityManager security = System.getSecurityManager();
-        if (security != null)
-            {
-            security.checkPermission(LocalPermission.BACKING_MAP);
-            }
 
         return getBackingMapInternal();
         }
@@ -12915,14 +12908,7 @@ public class Storage
             {
             // import com.tangosol.net.security.DoAsAction;
             // import com.tangosol.util.ObservableMap;
-            // import java.security.AccessController;
-
-            if (System.getSecurityManager() == null)
-                {
-                return getStorage().getBackingMap();
-                }
-
-            return (ObservableMap) AccessController.doPrivileged(getStorage().getBackingMapAction());
+            return getStorage().getBackingMap();
             }
 
         // From interface: com.tangosol.util.BinaryEntry

--- a/prj/coherence-core/src/main/java/com/tangosol/coherence/config/builder/SimpleParameterizedBuilderRegistry.java
+++ b/prj/coherence-core/src/main/java/com/tangosol/coherence/config/builder/SimpleParameterizedBuilderRegistry.java
@@ -8,7 +8,6 @@ package com.tangosol.coherence.config.builder;
 
 import com.oracle.coherence.common.base.Disposable;
 
-import com.tangosol.net.security.LocalPermission;
 
 import com.tangosol.util.Base;
 
@@ -118,12 +117,7 @@ public class SimpleParameterizedBuilderRegistry
                                       ParameterizedBuilder<? extends T> builder)
             throws IllegalArgumentException
         {
-        SecurityManager security = System.getSecurityManager();
-        if (security != null)
-            {
-            security.checkPermission(new LocalPermission("Service.registerResource"));
-            }
-
+       
         synchronized (clzInstance)
             {
             // attempt to get an existing registration for the key

--- a/prj/coherence-core/src/main/java/com/tangosol/net/CacheFactory.java
+++ b/prj/coherence-core/src/main/java/com/tangosol/net/CacheFactory.java
@@ -67,10 +67,7 @@ public abstract class CacheFactory
     */
     public static CacheFactoryBuilder getCacheFactoryBuilder()
         {
-        return System.getSecurityManager() == null
-                ? getCacheFactoryBuilderInternal()
-                : AccessController.doPrivileged((PrivilegedAction<CacheFactoryBuilder>)
-                    CacheFactory::getCacheFactoryBuilderInternal);
+        return getCacheFactoryBuilderInternal();
         }
 
     /**
@@ -118,12 +115,6 @@ public abstract class CacheFactory
     */
     public static synchronized void setCacheFactoryBuilder(CacheFactoryBuilder cfb)
         {
-        SecurityManager security = System.getSecurityManager();
-        if (security != null)
-            {
-            security.checkPermission(
-                new LocalPermission("CacheFactory.setCacheFactoryBuilder"));
-            }
 
         s_builder = cfb;
         checkConsistentCCFUsage();

--- a/prj/coherence-core/src/main/java/com/tangosol/net/ExtensibleConfigurableCacheFactory.java
+++ b/prj/coherence-core/src/main/java/com/tangosol/net/ExtensibleConfigurableCacheFactory.java
@@ -236,10 +236,7 @@ public class ExtensibleConfigurableCacheFactory
 
         Base.checkNotEmpty(sCacheName, "CacheName");
 
-        return System.getSecurityManager() == null
-                ? ensureCacheInternal(sCacheName, loader, options)
-                : AccessController.doPrivileged(new DoAsAction<>(
-                    () -> ensureCacheInternal(sCacheName, loader, options)));
+        return  ensureCacheInternal(sCacheName, loader, options);
         }
 
     /**

--- a/prj/coherence-core/src/main/java/com/tangosol/net/ScopedCacheFactoryBuilder.java
+++ b/prj/coherence-core/src/main/java/com/tangosol/net/ScopedCacheFactoryBuilder.java
@@ -277,10 +277,7 @@ public class ScopedCacheFactoryBuilder
                                                   final ClassLoader       loader,
                                                   final ParameterResolver resolver)
         {
-        return System.getSecurityManager() == null
-                ? getFactoryInternal(sConfigURI, loader, resolver)
-                : AccessController.doPrivileged((PrivilegedAction<ConfigurableCacheFactory>)
-                    () -> getFactoryInternal(sConfigURI, loader, resolver));
+        return getFactoryInternal(sConfigURI, loader, resolver);
         }
 
     /**

--- a/prj/coherence-core/src/main/java/com/tangosol/net/events/internal/Registry.java
+++ b/prj/coherence-core/src/main/java/com/tangosol/net/events/internal/Registry.java
@@ -81,12 +81,6 @@ public class Registry
      */
     public synchronized void unregisterEventInterceptor(String sIdentifier)
         {
-        SecurityManager security = System.getSecurityManager();
-        if (security != null)
-            {
-            security.checkPermission(
-                new LocalPermission("Service.registerEventInterceptor"));
-            }
 
         EventInterceptor interceptor = m_mapInterceptors.remove(sIdentifier);
         if (interceptor != null)

--- a/prj/coherence-core/src/main/java/com/tangosol/util/SimpleResourceRegistry.java
+++ b/prj/coherence-core/src/main/java/com/tangosol/util/SimpleResourceRegistry.java
@@ -7,7 +7,6 @@
 package com.tangosol.util;
 
 import com.oracle.coherence.common.base.Disposable;
-import com.tangosol.net.security.LocalPermission;
 
 import static com.tangosol.util.BuilderHelper.using;
 
@@ -164,13 +163,7 @@ public class SimpleResourceRegistry
     public <R> String registerResource(Class<R> clzResource, String sResourceName, Builder<? extends R> bldrResource,
                                        RegistrationBehavior behavior, ResourceLifecycleObserver<R> observer)
         {
-        SecurityManager security = System.getSecurityManager();
-        if (security != null)
-            {
-            security.checkPermission(
-                new LocalPermission("Service.registerResource"));
-            }
-
+      
         synchronized (clzResource)
             {
             // attempt to get an existing resource registration for the key
@@ -256,13 +249,6 @@ public class SimpleResourceRegistry
     @Override
     public <R> void unregisterResource(Class<R> clzResource, String sResourceName)
         {
-        SecurityManager security = System.getSecurityManager();
-        if (security != null)
-            {
-            security.checkPermission(
-                new LocalPermission("Service.registerResource"));
-            }
-
         m_mapResource.remove(new RegistryKey(clzResource, sResourceName));
         }
 

--- a/prj/test/functional/management/src/main/java/management/BaseManagementInfoResourceTests.java
+++ b/prj/test/functional/management/src/main/java/management/BaseManagementInfoResourceTests.java
@@ -3261,9 +3261,6 @@ public abstract class BaseManagementInfoResourceTests
     @Test
     public void testHealthChecks() 
         {
-        // skipped in security manager tests
-        Assume.assumeThat(System.getSecurityManager(), is(nullValue()));
-        Assume.assumeThat(System.getProperties().containsKey("java.security.manager"), is(false));
 
         // ensure the cluster is ready before this test starts so that
         // all health checks should be stable


### PR DESCRIPTION
remove SecurityManager references as per JEP 486 [ link - https://openjdk.org/jeps/486 ].

Important points captured from JEP 486 [ https://openjdk.org/jeps/486 ] for JDK24 + Security manager codes: 

—------------------------------------------------------------------------------------------------------------------------------------------------------
In JDK 24, where a Security Manager is never enabled, the System::getSecurityManager and AccessController::doPrivileged methods behave as they did in JDK 17 when a Security Manager was not enabled,

    System::getSecurityManager returns null,
    The SecurityManager::check* methods throw SecurityException, and
    The six AccessController::doPrivileged methods execute the given action immediately.


Rendering the Security Manager API non-functional

The Security Manager API consists of:

    Methods in the java.lang.SecurityManager class,
    Methods in the AccessController, AccessControlContext, Policy, and ProtectionDomain classes of the java.security package, and
    The getSecurityManager and setSecurityManager methods in the java.lang.System class.

We are not removing these methods from Java 24; rather, we are changing them to have no effect. They will, as appropriate, return null or false, or pass through the caller's request, or unconditionally throw a SecurityException.


—---------------------------------------------------------------------------------------------------------------------------

