### PR TITLE
Harden XML parsers against XXE attacks

### DIFF
--- a/prj/coherence-core/src/main/java/com/oracle/coherence/common/schema/XmlSchemaSource.java
+++ b/prj/coherence-core/src/main/java/com/oracle/coherence/common/schema/XmlSchemaSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * http://oss.oracle.com/licenses/upl.
@@ -103,6 +103,11 @@ public class XmlSchemaSource
             {
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
             dbf.setNamespaceAware(true);
+
+            // prevent XXE (XML External Entity) attacks
+            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
 
             DocumentBuilder db        = dbf.newDocumentBuilder();
             Document        doc       = db.parse(m_inputXml);

--- a/prj/coherence-core/src/main/java/com/tangosol/run/xml/SaxParser.java
+++ b/prj/coherence-core/src/main/java/com/tangosol/run/xml/SaxParser.java
@@ -535,6 +535,20 @@ public class SaxParser
                 ClassHelper.invoke(factory,
                     "setValidating", new Object[] {Boolean.FALSE});
 
+                // prevent XXE (XML External Entity) attacks
+                // factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                ClassHelper.invoke(factory,
+                    "setFeature", new Object[] {
+                        "http://xml.org/sax/features/external-general-entities", Boolean.FALSE});
+                // factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+                ClassHelper.invoke(factory,
+                    "setFeature", new Object[] {
+                        "http://xml.org/sax/features/external-parameter-entities", Boolean.FALSE});
+                // factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+                ClassHelper.invoke(factory,
+                    "setFeature", new Object[] {
+                        "http://apache.org/xml/features/nonvalidating/load-external-dtd", Boolean.FALSE});
+
                 // parser = factory.newSAXParser().getParser();
                 Object SAXParser = ClassHelper.invoke(factory,
                     "newSAXParser", ClassHelper.VOID);


### PR DESCRIPTION
## Summary

Two XML parser creation sites in `coherence-core` do not configure XXE (XML External Entity) protections. A crafted XML input can trigger external entity resolution to read local files, make outbound network connections, or cause denial of service via entity expansion.

## Changes

- **`XmlSchemaSource.java`**: Set `disallow-doctype-decl`, `external-general-entities=false`, `external-parameter-entities=false` on `DocumentBuilderFactory` before parsing.
- **`SaxParser.java`**: Set `external-general-entities=false`, `external-parameter-entities=false`, `load-external-dtd=false` on `SAXParserFactory` via `ClassHelper.invoke`, matching the existing reflection pattern used for `setValidating`.

## Attack scenario

An attacker who controls XML input passed to `XmlSchemaSource.populateSchema()` or `SaxParser.parseXml()` can craft a document with an external entity declaration:

```xml
<?xml version="1.0"?>
<!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
<schema><type name="&xxe;"/></schema>
```

Without the fix, the parser resolves the entity, reading local files or making outbound HTTP requests. With the fix, the parser rejects or ignores external entity declarations.

## Context

The codebase already acknowledges this risk: `ExternalizableHelper.java` line 2472 comments \*"Do not validate the XML to prevent XXE (XML eXternal Entity) injection"\* to skip the `SaxParser` path. However, the parsers themselves remained unprotected for direct callers. This has been present since the initial open-source release (2020-04-14).

Fixes #154